### PR TITLE
BuildConfig: add AAF-patched Groovy 2.0.8

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -33,6 +33,7 @@ grails.project.dependency.resolution = {
   }
 
   dependencies {
+    compile "org.codehaus:groovy-all:2.0.8+aaf.groovy7664"
     compile "commons-collections:commons-collections:3.2.2"
 
     test 'mysql:mysql-connector-java:5.1.18'


### PR DESCRIPTION
Hi Bradley,

Just noticed this when going over my repos again.  This is what I had to do to build an Attribute Validator WAR on Friday...

Without this, building the application ended up pulling the unpatched Groovy 2.0.8
instead of the patched one.  (And in application build configuration,
the unpatched version would be deleted, leaving the application with no
version of Groovy).

This was happening with Attribute Validator - works with this fix.